### PR TITLE
Use uiop to get/set env

### DIFF
--- a/cl-dotenv.asd
+++ b/cl-dotenv.asd
@@ -2,7 +2,8 @@
   :version "0.1.0"
   :author "Olle Lauri Boström"
   :license "MIT"
-  :depends-on (:cl-ppcre)
+  :depends-on ("cl-ppcre"
+               "uiop")
   :components ((:module "src"
                 :components
                 ((:file "cl-dotenv"))))

--- a/src/cl-dotenv.lisp
+++ b/src/cl-dotenv.lisp
@@ -4,7 +4,7 @@
 ;;; Inspiration from http://cl-cookbook.sourceforge.net/os.html & http://www.lispforum.com/viewtopic.php?f=2&t=446 & https://www.npmjs.com/package/dotenv
 
 (defpackage cl-dotenv
-  (:use :cl :cl-ppcre)
+  (:use :cl :cl-ppcre :uiop)
   (:export :load-env :get-env :set-env)
   (:nicknames :dotenv))
 (in-package :cl-dotenv)
@@ -15,24 +15,13 @@
       do (destructuring-bind (&optional name value &rest _) (cl-ppcre:split "=" line)
         (if (and name value)
           (set-env name value)
-          (error "Invalid .env file"))))
-    t))
+          (error "Invalid .env file"))))))
 
 (defun get-env (name &optional default)
   (or
-    #+Allegro (sys:getenv name)
-    #+CLISP (ext:getenv name)
-    #+ECL (si:getenv name)
-    #+SBCL (sb-unix::posix-getenv name)
-    #+LISPWORKS (lispworks:environment-variable name)
+    (uiop:getenv name)
     default))
 
 (defun set-env(name value)
-  (or
-    #+Allegro (setf (sys:getenv name) value)
-    #+CLISP (setf (ext:getenv name) value)
-    #+ECL (si:setenv name value)
-    #+SBCL (sb-posix:setenv name value 1)
-    #+LISPWORKS (setf (lispworks:environment-variable name) value)
-    (error "set-env is not supported for your Lisp implementation"))
-  t)
+  (setf (uiop:getenv name)
+        value))

--- a/tests/cl-dotenv.lisp
+++ b/tests/cl-dotenv.lisp
@@ -13,9 +13,11 @@
     (is (dotenv:get-env "NOT_SET") nil)))
 
 (subtest "cl-dotenv:set-env"
-  (subtest "set-env returns true & sets the environment"
-    (is (dotenv:set-env "TEST_VAR" "test") t)
-    (is (dotenv:get-env "TEST_VAR") "test")))
+  (subtest "set-env sets the environment"
+    (is (and 
+          (dotenv:set-env "TEST_VAR" "test") 
+          (dotenv:get-env "TEST_VAR"))
+        "test")))
 
 (subtest "cl-dotenv:load-env"
   (subtest "load-env throws error if .env file is corrupt"


### PR DESCRIPTION
Associated Issue: #5 

### Summary of Changes
* Declare the dependency to uiop in `cl-dotenv.asd`
* Use uiop to get/set env
